### PR TITLE
Change default channel from #general to #mychannelname

### DIFF
--- a/buildtask/SlackNotification/task.json
+++ b/buildtask/SlackNotification/task.json
@@ -51,7 +51,7 @@
             "type": "string",
             "label": "Channel",
             "required": true,
-            "defaultValue": "#mychannelname",
+            "defaultValue": "",
             "groupName": "notification",
             "helpMarkDown": "Channel/User where the message is sent to. E.g. #general, @kasunk"
         },

--- a/buildtask/SlackNotification/task.json
+++ b/buildtask/SlackNotification/task.json
@@ -34,7 +34,7 @@
             "name": "attachment",
             "displayName": "Attachment Options",
             "isExpanded": false
-        }        
+        }
     ],
     "inputs": [
         {
@@ -51,7 +51,7 @@
             "type": "string",
             "label": "Channel",
             "required": true,
-            "defaultValue": "#general",
+            "defaultValue": "#mychannelname",
             "groupName": "notification",
             "helpMarkDown": "Channel/User where the message is sent to. E.g. #general, @kasunk"
         },


### PR DESCRIPTION
Having the default channel set to #general in this task is risky because if users are not paying close attention they can set up tasks that spam a company-wide channel with a lot of unwanted messages. Having this set by default to `#mychannelname` will make it more obvious that this value should be changed from the default.