### PR TITLE
Adding capability of using variables as input on the PreText field.

### DIFF
--- a/buildtask/SlackNotification/TaskInput.ts
+++ b/buildtask/SlackNotification/TaskInput.ts
@@ -209,7 +209,7 @@ export class TaskInput implements ITaskInput {
             authorLink: this._authorLink,
             title: this._title,
             titleLink: this._titleLink,
-            preText: this._preText,
+            preText: process.env[this._preText],
             text: this._text,
             color: this._color,
             imageUrl: this._imageUrl,

--- a/buildtask/SlackNotification/task.json
+++ b/buildtask/SlackNotification/task.json
@@ -136,7 +136,7 @@
             "label": "Attachment Pre-Text",
             "required": false,
             "groupName": "notificationOptions",
-            "helpMarkDown": "This is optional text that appears above the message attachment block.",
+            "helpMarkDown": "This is optional text that appears above the message attachment block. If used, this fields requires a variable name. if the name of the variable is PreText, don't use $(PreText), simply use PReText as the content of this field and task will expand the variable content internally.",
             "visibleRule": "NotificationType = ChatMessage"
         },
         {


### PR DESCRIPTION
Adding capability of using variables as input on the PreText field. This will enable we format our msg beforehand and use the content provided via variables from other build tasks.

This fix also address issue #2 